### PR TITLE
restore: remote runtime + loopback + TUI wiring

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -682,6 +682,7 @@ dependencies = [
  "libc",
  "maplit",
  "mcp-types",
+ "native-tls",
  "openssl-sys",
  "os_info",
  "portable-pty",
@@ -702,12 +703,14 @@ dependencies = [
  "time",
  "tokio",
  "tokio-test",
+ "tokio-tungstenite",
  "tokio-util",
  "toml",
  "toml_edit",
  "tracing",
  "tree-sitter",
  "tree-sitter-bash",
+ "url",
  "uuid",
  "walkdir",
  "which",
@@ -1216,6 +1219,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deadpool"
@@ -4720,6 +4729,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4974,6 +4997,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5055,6 +5097,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -45,6 +45,7 @@ time = { version = "0.3", features = ["formatting", "parsing", "local-offset", "
 tokio = { version = "1", features = [
     "io-std",
     "macros",
+    "net",
     "process",
     "rt-multi-thread",
     "signal",
@@ -58,6 +59,9 @@ tree-sitter-bash = "0.25.0"
 uuid = { version = "1", features = ["serde", "v4"] }
 which = "6"
 wildmatch = "2.5.0"
+tokio-tungstenite = { version = "0.23", features = ["native-tls"] }
+native-tls = "0.2"
+url = "2"
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/codex-rs/core/src/codex_conversation.rs
+++ b/codex-rs/core/src/codex_conversation.rs
@@ -3,28 +3,51 @@ use crate::error::Result as CodexResult;
 use crate::protocol::Event;
 use crate::protocol::Op;
 use crate::protocol::Submission;
+use crate::remote::RemoteConversation;
+
+enum ConversationBackend {
+    Local(Codex),
+    Remote(RemoteConversation),
+}
 
 pub struct CodexConversation {
-    codex: Codex,
+    backend: ConversationBackend,
 }
 
 /// Conduit for the bidirectional stream of messages that compose a conversation
 /// in Codex.
 impl CodexConversation {
-    pub(crate) fn new(codex: Codex) -> Self {
-        Self { codex }
+    pub(crate) fn new_local(codex: Codex) -> Self {
+        Self {
+            backend: ConversationBackend::Local(codex),
+        }
+    }
+
+    pub(crate) fn new_remote(remote: RemoteConversation) -> Self {
+        Self {
+            backend: ConversationBackend::Remote(remote),
+        }
     }
 
     pub async fn submit(&self, op: Op) -> CodexResult<String> {
-        self.codex.submit(op).await
+        match &self.backend {
+            ConversationBackend::Local(codex) => codex.submit(op).await,
+            ConversationBackend::Remote(remote) => remote.submit(op).await,
+        }
     }
 
     /// Use sparingly: this is intended to be removed soon.
     pub async fn submit_with_id(&self, sub: Submission) -> CodexResult<()> {
-        self.codex.submit_with_id(sub).await
+        match &self.backend {
+            ConversationBackend::Local(codex) => codex.submit_with_id(sub).await,
+            ConversationBackend::Remote(remote) => remote.submit_with_id(sub).await,
+        }
     }
 
     pub async fn next_event(&self) -> CodexResult<Event> {
-        self.codex.next_event().await
+        match &self.backend {
+            ConversationBackend::Local(codex) => codex.next_event().await,
+            ConversationBackend::Remote(remote) => remote.next_event().await,
+        }
     }
 }

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -97,6 +97,12 @@ pub enum CodexErr {
     #[error("internal error; agent loop died unexpectedly")]
     InternalAgentDied,
 
+    #[error("remote event stream closed unexpectedly")]
+    RemoteStreamClosed,
+
+    #[error("remote transport error: {0}")]
+    RemoteTransport(String),
+
     /// Sandbox error
     #[error("sandbox error: {0}")]
     Sandbox(#[from] SandboxErr),

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -36,6 +36,7 @@ mod mcp_tool_call;
 mod message_history;
 mod model_provider_info;
 pub mod parse_command;
+mod remote;
 mod truncate;
 mod unified_exec;
 mod user_instructions;
@@ -49,6 +50,8 @@ mod event_mapping;
 pub use codex_protocol::protocol::InitialHistory;
 pub use conversation_manager::ConversationManager;
 pub use conversation_manager::NewConversation;
+pub use conversation_manager::RemoteConversationOptions;
+pub mod loopback_remote;
 // Re-export common auth types for workspace consumers
 pub use auth::AuthManager;
 pub use auth::CodexAuth;

--- a/codex-rs/core/src/loopback_remote.rs
+++ b/codex-rs/core/src/loopback_remote.rs
@@ -1,0 +1,210 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use rand::Rng;
+use rand::distr::Alphanumeric;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::task::JoinHandle;
+use tokio::time::{Instant, timeout};
+use tracing::{info, warn};
+use url::Url;
+
+use crate::config::Config;
+use crate::conversation_manager::RemoteConversationOptions;
+
+const LOOPBACK_TIMEOUT: Duration = Duration::from_secs(15);
+const DEFAULT_TOKEN_LEN: usize = 24;
+
+pub struct LoopbackRemote {
+    options: RemoteConversationOptions,
+    child: Option<Child>,
+    stdout_task: Option<JoinHandle<()>>,
+    stderr_task: Option<JoinHandle<()>>,
+}
+
+impl LoopbackRemote {
+    pub async fn start(config: &Config) -> Result<Self> {
+        let disable_env = std::env::var("SMARTY_TUI_REMOTE_DISABLE").unwrap_or_default();
+        if env_var_truthy(&disable_env) {
+            return Err(anyhow!(
+                "loopback remote disabled via SMARTY_TUI_REMOTE_DISABLE"
+            ));
+        }
+
+        let (command, args) = resolve_loopback_command(config)?;
+        let token = std::env::var("SMARTY_TUI_LOOPBACK_TOKEN").unwrap_or_else(|_| {
+            let mut rng = rand::rng();
+            (&mut rng)
+                .sample_iter(&Alphanumeric)
+                .take(DEFAULT_TOKEN_LEN)
+                .map(char::from)
+                .collect()
+        });
+
+        let mut child = Command::new(&command)
+            .args(&args)
+            .arg("--ws-bind")
+            .arg("127.0.0.1:0")
+            .arg("--http-bind")
+            .arg("127.0.0.1:0")
+            .arg("--token")
+            .arg(&token)
+            .arg("--root")
+            .arg(config.cwd.to_string_lossy().to_string())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to spawn loopback server using {command}"))?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("loopback server stdout not captured"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("loopback server stderr not captured"))?;
+
+        let mut stdout_reader = BufReader::new(stdout).lines();
+        let mut ws_url = None;
+        let mut http_url = None;
+        let deadline = Instant::now() + LOOPBACK_TIMEOUT;
+
+        while Instant::now() < deadline {
+            match timeout(
+                deadline.saturating_duration_since(Instant::now()),
+                stdout_reader.next_line(),
+            )
+            .await
+            {
+                Ok(Ok(Some(line))) => {
+                    let trimmed = line.trim();
+                    if let Some(rest) = trimmed.strip_prefix("listening ws://") {
+                        ws_url = Some(format!("ws://{}", rest.trim()));
+                    } else if let Some(rest) = trimmed.strip_prefix("listening http://") {
+                        http_url = Some(format!("http://{}", rest.trim()));
+                    } else {
+                        info!(target = "remote", "loopback: {trimmed}");
+                    }
+
+                    if ws_url.is_some() && http_url.is_some() {
+                        break;
+                    }
+                }
+                Ok(Ok(None)) => {
+                    return Err(anyhow!(
+                        "loopback server exited before reporting bind addresses"
+                    ));
+                }
+                Ok(Err(err)) => {
+                    return Err(anyhow!("error reading loopback server stdout: {err}"));
+                }
+                Err(_) => {
+                    return Err(anyhow!(
+                        "timed out waiting for loopback server to report bind addresses"
+                    ));
+                }
+            }
+        }
+
+        let ws_url =
+            ws_url.ok_or_else(|| anyhow!("loopback server did not report ws bind address"))?;
+        let http_url =
+            http_url.ok_or_else(|| anyhow!("loopback server did not report http bind address"))?;
+
+        let remote_url = Url::parse(&ws_url)
+            .with_context(|| format!("invalid ws url reported by loopback server: {ws_url}"))?;
+        let sse_base_url = Url::parse(&http_url)
+            .with_context(|| format!("invalid http url reported by loopback server: {http_url}"))?;
+
+        let stdout_task = tokio::spawn(async move {
+            while let Ok(Some(line)) = stdout_reader.next_line().await {
+                info!(target = "remote", "loopback: {line}");
+            }
+        });
+
+        let mut stderr_reader = BufReader::new(stderr).lines();
+        let stderr_task = tokio::spawn(async move {
+            while let Ok(Some(line)) = stderr_reader.next_line().await {
+                warn!(target = "remote", "loopback stderr: {line}");
+            }
+        });
+
+        let options = RemoteConversationOptions {
+            remote_url,
+            sse_base_url,
+            token: Some(token),
+            timeout: Duration::from_secs(45),
+            trust_cert: None,
+        };
+
+        Ok(Self {
+            options,
+            child: Some(child),
+            stdout_task: Some(stdout_task),
+            stderr_task: Some(stderr_task),
+        })
+    }
+
+    pub fn options(&self) -> &RemoteConversationOptions {
+        &self.options
+    }
+}
+
+impl Drop for LoopbackRemote {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.start_kill();
+        }
+        if let Some(handle) = self.stdout_task.take() {
+            handle.abort();
+        }
+        if let Some(handle) = self.stderr_task.take() {
+            handle.abort();
+        }
+    }
+}
+
+fn env_var_truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn resolve_loopback_command(config: &Config) -> Result<(String, Vec<String>)> {
+    if let Ok(cmdline) = std::env::var("SMARTY_TUI_LOOPBACK_SERVER_CMD") {
+        let mut parts = shlex::split(&cmdline)
+            .ok_or_else(|| anyhow!("failed to parse SMARTY_TUI_LOOPBACK_SERVER_CMD: {cmdline}"))?;
+        if parts.is_empty() {
+            return Err(anyhow!("SMARTY_TUI_LOOPBACK_SERVER_CMD is empty"));
+        }
+        let program = parts.remove(0);
+        return Ok((program, parts));
+    }
+
+    let script = locate_repo_script(&config.cwd, "scripts/smarty-tui-server").ok_or_else(|| {
+        anyhow!(
+            "unable to locate scripts/smarty-tui-server from cwd {}",
+            config.cwd.display()
+        )
+    })?;
+    Ok((script.to_string_lossy().to_string(), Vec::new()))
+}
+
+fn locate_repo_script(start: &Path, relative: &str) -> Option<PathBuf> {
+    let mut dir = start;
+    loop {
+        let candidate = dir.join(relative);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => break,
+        }
+    }
+    None
+}

--- a/codex-rs/core/src/remote.rs
+++ b/codex-rs/core/src/remote.rs
@@ -1,0 +1,540 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use async_channel::{Receiver, Sender, bounded};
+use futures::{SinkExt, StreamExt};
+use native_tls::{Certificate as NativeTlsCertificate, TlsConnector};
+use reqwest::Certificate as HttpCertificate;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::net::TcpStream;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_tungstenite::tungstenite::protocol::Message;
+use tokio_tungstenite::{
+    Connector, MaybeTlsStream, WebSocketStream, connect_async, connect_async_tls_with_config,
+};
+use tokio_util::codec::{Framed, LinesCodec};
+use tracing::{info, warn};
+use url::Url;
+
+use crate::error::{CodexErr, Result as CodexResult};
+use crate::protocol::{Event, Op, SessionConfiguredEvent, Submission};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone)]
+pub(crate) struct RemoteSpawnParams {
+    pub remote: Url,
+    pub sse_base: Url,
+    pub token: Option<String>,
+    pub cwd: Option<PathBuf>,
+    pub timeout: Option<Duration>,
+    pub trust_cert: Option<Vec<u8>>,
+}
+
+pub(crate) struct RemoteSpawnedConversation {
+    pub conversation: RemoteConversation,
+    pub session_configured: SessionConfiguredEvent,
+}
+
+pub(crate) struct RemoteConversation {
+    conversation_id: String,
+    rpc: Arc<Mutex<RpcClient>>,
+    event_rx: Receiver<Event>,
+    shutdown: Arc<AtomicBool>,
+    event_task: Option<JoinHandle<()>>,
+}
+
+impl RemoteConversation {
+    pub(crate) fn conversation_id(&self) -> &str {
+        &self.conversation_id
+    }
+
+    pub(crate) async fn submit(&self, op: Op) -> CodexResult<String> {
+        let params = json!({
+            "conversation_id": self.conversation_id,
+            "op": op,
+            "echo_user": true,
+        });
+        let mut client = self.rpc.lock().await;
+        let value = client.request("submit", params).await?;
+        let id = value
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| CodexErr::RemoteTransport("submit response missing id".to_string()))?;
+        Ok(id.to_string())
+    }
+
+    pub(crate) async fn submit_with_id(&self, sub: Submission) -> CodexResult<()> {
+        let params = json!({
+            "conversation_id": self.conversation_id,
+            "sub": sub,
+        });
+        let mut client = self.rpc.lock().await;
+        let _ = client.request("submit_with_id", params).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn next_event(&self) -> CodexResult<Event> {
+        match self.event_rx.recv().await {
+            Ok(event) => Ok(event),
+            Err(_) => Err(CodexErr::RemoteStreamClosed),
+        }
+    }
+}
+
+impl Drop for RemoteConversation {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.event_task.take() {
+            handle.abort();
+        }
+    }
+}
+
+pub(crate) async fn spawn_remote_conversation(
+    params: RemoteSpawnParams,
+) -> CodexResult<RemoteSpawnedConversation> {
+    let timeout = params.timeout.unwrap_or(DEFAULT_TIMEOUT);
+    let trust = params.trust_cert.clone();
+    let mut client = RpcClient::connect(&params.remote, timeout, trust.clone()).await?;
+
+    let mut spawn_params = serde_json::Map::new();
+    if let Some(cwd) = params.cwd.clone() {
+        spawn_params.insert(
+            "cwd".to_string(),
+            Value::String(cwd.to_string_lossy().into_owned()),
+        );
+    }
+    if let Some(token) = params.token.clone() {
+        spawn_params.insert("token".to_string(), Value::String(token));
+    }
+
+    let value = client.request("spawn", Value::Object(spawn_params)).await?;
+
+    #[derive(Deserialize)]
+    struct SpawnResponse {
+        conversation_id: String,
+        session_configured: SessionConfiguredEvent,
+    }
+
+    let spawn: SpawnResponse = serde_json::from_value(value)
+        .map_err(|e| CodexErr::RemoteTransport(format!("invalid spawn response: {e}")))?;
+
+    let (event_tx, event_rx) = bounded::<Event>(256);
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let stream_opts = EventStreamOptions {
+        sse_base: params.sse_base,
+        token: params.token,
+        trust_cert: params.trust_cert,
+    };
+
+    let conversation_id = spawn.conversation_id.clone();
+    let shutdown_clone = shutdown.clone();
+    let event_task = tokio::spawn(async move {
+        stream_events(conversation_id, stream_opts, event_tx, shutdown_clone).await;
+    });
+
+    let conversation = RemoteConversation {
+        conversation_id: spawn.conversation_id,
+        rpc: Arc::new(Mutex::new(client)),
+        event_rx,
+        shutdown,
+        event_task: Some(event_task),
+    };
+
+    Ok(RemoteSpawnedConversation {
+        conversation,
+        session_configured: spawn.session_configured,
+    })
+}
+
+struct EventStreamOptions {
+    sse_base: Url,
+    token: Option<String>,
+    trust_cert: Option<Vec<u8>>,
+}
+
+async fn stream_events(
+    conversation_id: String,
+    opts: EventStreamOptions,
+    sender: Sender<Event>,
+    shutdown: Arc<AtomicBool>,
+) {
+    let mut last_seq: u64 = 1;
+
+    while !shutdown.load(Ordering::Relaxed) {
+        match open_sse_stream(&conversation_id, last_seq, &opts).await {
+            Ok(response) => {
+                info!(target: "remote", "connected SSE stream for conversation {conversation_id}");
+                let mut buffer: Vec<u8> = Vec::new();
+                let mut data_lines: Vec<String> = Vec::new();
+                let mut stream = response.bytes_stream();
+
+                while let Some(chunk) = stream.next().await {
+                    match chunk {
+                        Ok(bytes) => {
+                            buffer.extend_from_slice(&bytes);
+                            while let Some(pos) = buffer.iter().position(|&b| b == b'\n') {
+                                let mut line = buffer.drain(..=pos).collect::<Vec<u8>>();
+                                if line.ends_with(&[b'\n']) {
+                                    line.pop();
+                                }
+                                if line.ends_with(&[b'\r']) {
+                                    line.pop();
+                                }
+                                if line.is_empty() {
+                                    if data_lines.is_empty() {
+                                        continue;
+                                    }
+                                    let joined = data_lines.join("\n");
+                                    data_lines.clear();
+                                    let trimmed = joined.trim();
+                                    if trimmed.is_empty()
+                                        || trimmed.eq_ignore_ascii_case("keepalive")
+                                    {
+                                        continue;
+                                    }
+                                    let value: Value = match serde_json::from_str(trimmed) {
+                                        Ok(v) => v,
+                                        Err(err) => {
+                                            warn!(
+                                                target: "remote",
+                                                "ignoring malformed SSE payload: {err}"
+                                            );
+                                            continue;
+                                        }
+                                    };
+                                    let seq = value
+                                        .get("event_seq")
+                                        .and_then(|v| v.as_u64())
+                                        .unwrap_or(last_seq);
+                                    let event: Event = match serde_json::from_value(value.clone()) {
+                                        Ok(ev) => ev,
+                                        Err(err) => {
+                                            warn!(
+                                                target: "remote",
+                                                "failed to decode SSE event: {err}"
+                                            );
+                                            continue;
+                                        }
+                                    };
+                                    last_seq = seq.max(1);
+                                    if sender.send(event).await.is_err() {
+                                        return;
+                                    }
+                                } else if line.starts_with(b":") {
+                                    continue;
+                                } else if line.starts_with(b"data:") {
+                                    let data = &line[5..];
+                                    match String::from_utf8(data.to_vec()) {
+                                        Ok(text) => {
+                                            if let Some(rest) = text.strip_prefix(' ') {
+                                                data_lines.push(rest.to_string());
+                                            } else {
+                                                data_lines.push(text);
+                                            }
+                                        }
+                                        Err(err) => {
+                                            warn!(
+                                                target: "remote",
+                                                "invalid UTF-8 in SSE data: {err}"
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            warn!(target: "remote", "SSE stream error: {err}");
+                            break;
+                        }
+                    }
+
+                    if shutdown.load(Ordering::Relaxed) {
+                        break;
+                    }
+                }
+            }
+            Err(err) => {
+                warn!(target: "remote", "failed to connect SSE stream: {err}");
+            }
+        }
+
+        if shutdown.load(Ordering::Relaxed) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    sender.close();
+}
+
+async fn open_sse_stream(
+    conversation_id: &str,
+    from_seq: u64,
+    opts: &EventStreamOptions,
+) -> Result<reqwest::Response, String> {
+    let mut url = opts
+        .sse_base
+        .join(&format!("sessions/{conversation_id}/events"))
+        .map_err(|e| format!("invalid SSE base: {e}"))?;
+    {
+        let mut pairs = url.query_pairs_mut();
+        pairs.append_pair("from_seq", &from_seq.to_string());
+        if let Some(token) = &opts.token {
+            pairs.append_pair("token", token);
+        }
+    }
+
+    let mut builder = reqwest::Client::builder();
+    builder = builder.redirect(reqwest::redirect::Policy::none());
+    if url.scheme() == "https" {
+        if let Some(bytes) = opts.trust_cert.clone() {
+            match HttpCertificate::from_pem(&bytes) {
+                Ok(cert) => {
+                    builder = builder
+                        .danger_accept_invalid_certs(true)
+                        .add_root_certificate(cert);
+                }
+                Err(err) => {
+                    return Err(format!("failed to parse trust cert: {err}"));
+                }
+            }
+        }
+    }
+
+    let client = builder
+        .build()
+        .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+
+    let mut request = client.get(url).header("Accept", "text/event-stream");
+    if let Some(token) = &opts.token {
+        request = request
+            .header("X-Smarty-Token", token)
+            .header("Authorization", format!("Bearer {token}"));
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("failed to open SSE stream: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("SSE endpoint returned error: {e}"))?;
+
+    Ok(response)
+}
+
+struct RpcClient {
+    transport: Transport,
+    next_id: u64,
+    timeout: Duration,
+}
+
+enum Transport {
+    Ws(WebSocketStream<MaybeTlsStream<TcpStream>>),
+    Tcp(Framed<TcpStream, LinesCodec>),
+}
+
+impl RpcClient {
+    async fn connect(
+        remote: &Url,
+        timeout: Duration,
+        trust_cert: Option<Vec<u8>>,
+    ) -> CodexResult<Self> {
+        let transport = match remote.scheme() {
+            "ws" | "wss" => {
+                let connector = if remote.scheme() == "wss" {
+                    let mut builder = TlsConnector::builder();
+                    if let Some(bytes) = trust_cert.clone() {
+                        match NativeTlsCertificate::from_pem(&bytes) {
+                            Ok(cert) => {
+                                builder.add_root_certificate(cert);
+                                builder.danger_accept_invalid_certs(true);
+                                builder.danger_accept_invalid_hostnames(true);
+                            }
+                            Err(err) => {
+                                return Err(CodexErr::RemoteTransport(format!(
+                                    "failed to parse trust cert: {err}"
+                                )));
+                            }
+                        }
+                    }
+                    match builder.build() {
+                        Ok(conn) => Some(Connector::NativeTls(conn)),
+                        Err(err) => {
+                            return Err(CodexErr::RemoteTransport(format!(
+                                "failed to build TLS connector: {err}"
+                            )));
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                let url = remote.to_string();
+                let fut = async {
+                    match connector {
+                        Some(conn) => {
+                            connect_async_tls_with_config(url.as_str(), None, false, Some(conn))
+                                .await
+                        }
+                        None => connect_async(url.as_str()).await,
+                    }
+                };
+                let (stream, _) = tokio::time::timeout(timeout, fut)
+                    .await
+                    .map_err(|_| {
+                        CodexErr::RemoteTransport("timeout establishing websocket".into())
+                    })?
+                    .map_err(|e| {
+                        CodexErr::RemoteTransport(format!("websocket handshake error: {e}"))
+                    })?;
+                Transport::Ws(stream)
+            }
+            "tcp" => {
+                let host = remote
+                    .host_str()
+                    .ok_or_else(|| CodexErr::RemoteTransport("tcp URL missing host".into()))?;
+                let port = remote
+                    .port()
+                    .ok_or_else(|| CodexErr::RemoteTransport("tcp URL missing port".into()))?;
+                let addr = format!("{host}:{port}");
+                let stream = tokio::time::timeout(timeout, TcpStream::connect(addr))
+                    .await
+                    .map_err(|_| {
+                        CodexErr::RemoteTransport("timeout connecting to tcp endpoint".into())
+                    })?
+                    .map_err(|e| {
+                        CodexErr::RemoteTransport(format!("failed to connect to tcp endpoint: {e}"))
+                    })?;
+                Transport::Tcp(Framed::new(stream, LinesCodec::new()))
+            }
+            other => {
+                return Err(CodexErr::RemoteTransport(format!(
+                    "unsupported remote scheme: {other}"
+                )));
+            }
+        };
+
+        Ok(Self {
+            transport,
+            next_id: 1,
+            timeout,
+        })
+    }
+
+    async fn request(&mut self, method: &str, params: Value) -> CodexResult<Value> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let id_str = id.to_string();
+        let payload = json!({
+            "id": id_str,
+            "method": method,
+            "params": params,
+        });
+        let text = serde_json::to_string(&payload)?;
+        match &mut self.transport {
+            Transport::Ws(stream) => {
+                stream
+                    .send(Message::Text(text))
+                    .await
+                    .map_err(|e| CodexErr::RemoteTransport(format!("ws send failed: {e}")))?;
+            }
+            Transport::Tcp(framed) => {
+                framed
+                    .send(text)
+                    .await
+                    .map_err(|e| CodexErr::RemoteTransport(format!("tcp send failed: {e}")))?;
+            }
+        }
+
+        loop {
+            let value = self.recv_json().await?;
+            let msg_id = value.get("id").and_then(|v| v.as_str()).unwrap_or_default();
+            if msg_id != id_str {
+                continue;
+            }
+            if let Some(err) = value.get("error") {
+                let message = match err {
+                    Value::String(s) => s.clone(),
+                    Value::Object(map) => map
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| err.to_string()),
+                    _ => err.to_string(),
+                };
+                return Err(CodexErr::RemoteTransport(message));
+            }
+            return Ok(value.get("result").cloned().unwrap_or(Value::Null));
+        }
+    }
+
+    async fn recv_json(&mut self) -> CodexResult<Value> {
+        match &mut self.transport {
+            Transport::Ws(stream) => loop {
+                let next = tokio::time::timeout(self.timeout, stream.next())
+                    .await
+                    .map_err(|_| {
+                        CodexErr::RemoteTransport("timeout waiting for websocket message".into())
+                    })?;
+                let msg = next.transpose().map_err(|e| {
+                    CodexErr::RemoteTransport(format!("websocket receive error: {e}"))
+                })?;
+                let msg = msg.ok_or_else(|| {
+                    CodexErr::RemoteTransport("websocket closed unexpectedly".into())
+                })?;
+                match msg {
+                    Message::Text(text) => {
+                        return serde_json::from_str(&text).map_err(CodexErr::from);
+                    }
+                    Message::Binary(bin) => {
+                        if let Ok(text) = String::from_utf8(bin) {
+                            if let Ok(val) = serde_json::from_str(&text) {
+                                return Ok(val);
+                            }
+                        }
+                    }
+                    Message::Ping(data) => {
+                        stream.send(Message::Pong(data)).await.map_err(|e| {
+                            CodexErr::RemoteTransport(format!("failed to respond to ping: {e}"))
+                        })?;
+                    }
+                    Message::Pong(_) => continue,
+                    Message::Close(frame) => {
+                        return Err(CodexErr::RemoteTransport(format!(
+                            "websocket closed: {:?}",
+                            frame
+                        )));
+                    }
+                    _ => continue,
+                }
+            },
+            Transport::Tcp(framed) => loop {
+                let msg = tokio::time::timeout(self.timeout, framed.next())
+                    .await
+                    .map_err(|_| {
+                        CodexErr::RemoteTransport("timeout waiting for tcp frame".into())
+                    })?;
+                match msg {
+                    Some(Ok(line)) => {
+                        if line.trim().is_empty() {
+                            continue;
+                        }
+                        return serde_json::from_str(&line).map_err(CodexErr::from);
+                    }
+                    Some(Err(err)) => {
+                        return Err(CodexErr::RemoteTransport(format!(
+                            "tcp stream error: {err}"
+                        )));
+                    }
+                    None => return Err(CodexErr::RemoteTransport("tcp stream closed".into())),
+                }
+            },
+        }
+    }
+}

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = "1"
 async-stream = "0.3.6"
 base64 = "0.22.1"
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 codex-ansi-escape = { path = "../ansi-escape" }
 codex-arg0 = { path = "../arg0" }
 codex-common = { path = "../common", features = [

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -72,6 +72,26 @@ pub struct Cli {
     #[arg(long = "search", default_value_t = false)]
     pub web_search: bool,
 
+    /// Remote control endpoint (ws://, wss://, tcp://) for remote attach mode.
+    #[arg(long = "remote", value_name = "URL", env = "SMARTY_TUI_REMOTE")]
+    pub remote: Option<String>,
+
+    /// Base URL for remote SSE event stream (http:// or https://).
+    #[arg(long = "sse-base", value_name = "URL", env = "SMARTY_TUI_SSE_BASE")]
+    pub sse_base: Option<String>,
+
+    /// Shared secret token for remote attach mode.
+    #[arg(long = "token", value_name = "TOKEN", env = "SMARTY_TUI_TOKEN")]
+    pub remote_token: Option<String>,
+
+    /// Timeout in seconds for remote RPC operations.
+    #[arg(
+        long = "remote-timeout-secs",
+        value_name = "SECONDS",
+        env = "SMARTY_TUI_REMOTE_TIMEOUT_SECS"
+    )]
+    pub remote_timeout_secs: Option<u64>,
+
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
 }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -7,6 +7,8 @@ use app::App;
 use codex_core::AuthManager;
 use codex_core::BUILT_IN_OSS_MODEL_PROVIDER_ID;
 use codex_core::CodexAuth;
+use codex_core::loopback_remote::LoopbackRemote;
+use codex_core::RemoteConversationOptions;
 use codex_core::RolloutRecorder;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
@@ -23,10 +25,12 @@ use codex_protocol::config_types::SandboxMode;
 use codex_protocol::mcp_protocol::AuthMode;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
+use std::time::Duration;
 use tracing::error;
 use tracing_appender::non_blocking;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::prelude::*;
+use url::Url;
 
 mod app;
 mod app_backtrack;
@@ -198,6 +202,109 @@ pub async fn run_main(
 
     let internal_storage = InternalStorage::load(&config.codex_home);
 
+    let remote_mode_env = std::env::var("SMARTY_TUI_MODE").ok();
+    let force_remote = remote_mode_env
+        .as_ref()
+        .map(|value| value.eq_ignore_ascii_case("remote"))
+        .unwrap_or(false);
+
+    let remote_requested = cli.remote.is_some() || force_remote;
+    let (remote_options, _loopback_guard) = if remote_requested {
+        let remote_str = match &cli.remote {
+            Some(value) => value.clone(),
+            None => {
+                #[allow(clippy::print_stderr)]
+                {
+                    eprintln!(
+                        "SMARTY_TUI_MODE=remote requires --remote or SMARTY_TUI_REMOTE to be set"
+                    );
+                }
+                std::process::exit(1);
+            }
+        };
+
+        let remote_url = match Url::parse(&remote_str) {
+            Ok(url) => url,
+            Err(err) => {
+                #[allow(clippy::print_stderr)]
+                {
+                    eprintln!("Invalid remote URL '{remote_str}': {err}");
+                }
+                std::process::exit(1);
+            }
+        };
+
+        match remote_url.scheme() {
+            "ws" | "wss" | "tcp" => {}
+            other => {
+                #[allow(clippy::print_stderr)]
+                {
+                    eprintln!("Unsupported remote scheme '{other}'. Use ws://, wss://, or tcp://");
+                }
+                std::process::exit(1);
+            }
+        }
+
+        let sse_base_url = if let Some(sse) = cli.sse_base.clone() {
+            match Url::parse(&sse) {
+                Ok(url) => url,
+                Err(err) => {
+                    #[allow(clippy::print_stderr)]
+                    {
+                        eprintln!("Invalid --sse-base URL '{sse}': {err}");
+                    }
+                    std::process::exit(1);
+                }
+            }
+        } else if let Some(derived) = derive_default_sse_base(&remote_url) {
+            derived
+        } else {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!(
+                    "--sse-base is required when using remote scheme '{}'",
+                    remote_url.scheme()
+                );
+            }
+            std::process::exit(1);
+        };
+
+        let timeout_secs = cli.remote_timeout_secs.unwrap_or(30).max(1);
+
+        let trust_cert_bytes = match std::env::var("SMARTY_TUI_TRUST_CERT") {
+            Ok(path) => match std::fs::read(&path) {
+                Ok(bytes) => Some(bytes),
+                Err(err) => {
+                    #[allow(clippy::print_stderr)]
+                    {
+                        eprintln!("Failed to read SMARTY_TUI_TRUST_CERT at {}: {err}", path);
+                    }
+                    std::process::exit(1);
+                }
+            },
+            Err(_) => None,
+        };
+
+        (Some(RemoteConversationOptions {
+            remote_url,
+            sse_base_url,
+            token: cli.remote_token.clone(),
+            timeout: Duration::from_secs(timeout_secs),
+            trust_cert: trust_cert_bytes,
+        }), None)
+    } else {
+        match LoopbackRemote::start(&config).await {
+            Ok(loopback) => {
+                let options = loopback.options().clone();
+                (Some(options), Some(loopback))
+            }
+            Err(err) => {
+                tracing::warn!(target: "remote", "Loopback remote unavailable: {err}");
+                (None, None)
+            }
+        }
+    };
+
     let log_dir = codex_core::config::log_dir(&config)?;
     std::fs::create_dir_all(&log_dir)?;
     // Open (or create) your log file, appending to it.
@@ -246,6 +353,7 @@ pub async fn run_main(
         internal_storage,
         active_profile,
         should_show_trust_screen,
+        remote_options,
     )
     .await
     .map_err(|err| std::io::Error::other(err.to_string()))
@@ -257,6 +365,7 @@ async fn run_ratatui_app(
     mut internal_storage: InternalStorage,
     active_profile: Option<String>,
     should_show_trust_screen: bool,
+    remote_options: Option<RemoteConversationOptions>,
 ) -> color_eyre::Result<codex_core::protocol::TokenUsage> {
     let mut config = config;
     color_eyre::install()?;
@@ -417,6 +526,7 @@ async fn run_ratatui_app(
         prompt,
         images,
         resume_selection,
+        remote_options,
     )
     .await;
 
@@ -425,6 +535,27 @@ async fn run_ratatui_app(
     session_log::log_session_end();
     // ignore error when collecting usage – report underlying error instead
     app_result
+}
+
+fn derive_default_sse_base(remote: &Url) -> Option<Url> {
+    match remote.scheme() {
+        "ws" | "wss" => {
+            let mut derived = remote.clone();
+            let new_scheme = if remote.scheme() == "wss" {
+                "https"
+            } else {
+                "http"
+            };
+            derived.set_scheme(new_scheme).ok()?;
+            if derived.path() != "/" {
+                derived.set_path("/");
+            }
+            derived.set_query(None);
+            derived.set_fragment(None);
+            Some(derived)
+        }
+        _ => None,
+    }
 }
 
 #[expect(


### PR DESCRIPTION
Restores local WIP that never landed with the consolidation PR.

Changes
- core: introduce remote.rs + loopback_remote.rs; expand conversation manager; small error/lib tweaks
- tui: lib/app/cli wiring to exercise remote flows
- lockfiles + Cargo.toml touches

Context
- Originated in the smarty-dev worktree `wt/20250916-022201-smarty-tui-consolidation`; preserved via salvage backups on 2025‑09‑20.
- Follow‑up in smarty-dev will bump the submodule pointer after this merges.

Safety
- No API keys or secrets; code only. Builds expected to pass with the existing workspace.