### PR TITLE
Add remote exit-after-turn TUI mode

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -650,6 +650,10 @@ struct InteractiveRemoteOptions {
     #[arg(long = "remote", value_name = "ADDR")]
     remote: Option<String>,
 
+    /// Exit after the initial remote turn completes.
+    #[arg(long = "exit-after-turn", default_value_t = false)]
+    exit_after_turn: bool,
+
     /// Name of the environment variable containing the bearer token to send to
     /// a remote app server websocket.
     #[arg(long = "remote-auth-token-env", value_name = "ENV_VAR")]
@@ -730,6 +734,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
     // Fold --enable/--disable into config overrides so they flow to all subcommands.
     let toggle_overrides = feature_toggles.to_overrides()?;
     root_config_overrides.raw_overrides.extend(toggle_overrides);
+    let root_exit_after_turn = remote.exit_after_turn;
     let root_remote = remote.remote;
     let root_remote_auth_token_env = remote.remote_auth_token_env;
 
@@ -743,6 +748,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 interactive,
                 root_remote.clone(),
                 root_remote_auth_token_env.clone(),
+                root_exit_after_turn,
                 arg0_paths.clone(),
             )
             .await?;
@@ -752,6 +758,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "exec",
             )?;
             exec_cli
@@ -767,6 +774,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "review",
             )?;
             let mut exec_cli = ExecCli::try_parse_from(["codex", "exec"])?;
@@ -781,6 +789,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "mcp-server",
             )?;
             codex_mcp_server::run_main(arg0_paths.clone(), root_config_overrides).await?;
@@ -789,6 +798,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "mcp",
             )?;
             // Propagate any root-level config overrides (e.g. `-c key=value`).
@@ -799,6 +809,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "plugin",
             )?;
             let PluginCli {
@@ -823,6 +834,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_app_server_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 subcommand.as_ref(),
             )?;
             match subcommand {
@@ -877,6 +889,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "app",
             )?;
             app_cmd::run_app(app_cli).await?;
@@ -904,6 +917,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 remote
                     .remote_auth_token_env
                     .or(root_remote_auth_token_env.clone()),
+                remote.exit_after_turn || root_exit_after_turn,
                 arg0_paths.clone(),
             )
             .await?;
@@ -930,6 +944,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 remote
                     .remote_auth_token_env
                     .or(root_remote_auth_token_env.clone()),
+                remote.exit_after_turn || root_exit_after_turn,
                 arg0_paths.clone(),
             )
             .await?;
@@ -939,6 +954,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "login",
             )?;
             prepend_config_flags(
@@ -984,6 +1000,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "logout",
             )?;
             prepend_config_flags(
@@ -996,6 +1013,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "completion",
             )?;
             print_completion(completion_cli);
@@ -1004,6 +1022,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "cloud",
             )?;
             prepend_config_flags(
@@ -1018,6 +1037,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "sandbox macos",
                 )?;
                 prepend_config_flags(
@@ -1034,6 +1054,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "sandbox linux",
                 )?;
                 prepend_config_flags(
@@ -1050,6 +1071,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "sandbox windows",
                 )?;
                 prepend_config_flags(
@@ -1068,6 +1090,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "debug models",
                 )?;
                 run_debug_models_command(cmd, root_config_overrides).await?;
@@ -1076,6 +1099,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "debug app-server",
                 )?;
                 run_debug_app_server_command(cmd).await?;
@@ -1084,6 +1108,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "debug prompt-input",
                 )?;
                 run_debug_prompt_input_command(
@@ -1098,6 +1123,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "debug trace-reduce",
                 )?;
                 run_debug_trace_reduce_command(cmd).await?;
@@ -1106,6 +1132,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "debug clear-memories",
                 )?;
                 run_debug_clear_memories_command(&root_config_overrides, &interactive).await?;
@@ -1116,6 +1143,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "execpolicy check",
                 )?;
                 run_execpolicycheck(cmd)?
@@ -1125,6 +1153,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "apply",
             )?;
             prepend_config_flags(
@@ -1137,6 +1166,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "responses-api-proxy",
             )?;
             tokio::task::spawn_blocking(move || codex_responses_api_proxy::run_main(args))
@@ -1146,6 +1176,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "stdio-to-uds",
             )?;
             let socket_path = cmd.socket_path;
@@ -1155,6 +1186,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
             reject_remote_mode_for_subcommand(
                 root_remote.as_deref(),
                 root_remote_auth_token_env.as_deref(),
+                root_exit_after_turn,
                 "exec-server",
             )?;
             run_exec_server_command(cmd, &arg0_paths).await?;
@@ -1164,6 +1196,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "features list",
                 )?;
                 // Respect root-level `-c` overrides plus top-level flags like `--profile`.
@@ -1211,6 +1244,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "features enable",
                 )?;
                 enable_feature_in_config(&interactive, &feature).await?;
@@ -1219,6 +1253,7 @@ async fn cli_main(arg0_paths: Arg0DispatchPaths) -> anyhow::Result<()> {
                 reject_remote_mode_for_subcommand(
                     root_remote.as_deref(),
                     root_remote_auth_token_env.as_deref(),
+                    root_exit_after_turn,
                     "features disable",
                 )?;
                 disable_feature_in_config(&interactive, &feature).await?;
@@ -1454,6 +1489,7 @@ fn prepend_config_flags(
 fn reject_remote_mode_for_subcommand(
     remote: Option<&str>,
     remote_auth_token_env: Option<&str>,
+    exit_after_turn: bool,
     subcommand: &str,
 ) -> anyhow::Result<()> {
     if let Some(remote) = remote {
@@ -1466,12 +1502,18 @@ fn reject_remote_mode_for_subcommand(
             "`--remote-auth-token-env` is only supported for interactive TUI commands, not `codex {subcommand}`"
         );
     }
+    if exit_after_turn {
+        anyhow::bail!(
+            "`--exit-after-turn` is only supported for interactive TUI commands, not `codex {subcommand}`"
+        );
+    }
     Ok(())
 }
 
 fn reject_remote_mode_for_app_server_subcommand(
     remote: Option<&str>,
     remote_auth_token_env: Option<&str>,
+    exit_after_turn: bool,
     subcommand: Option<&AppServerSubcommand>,
 ) -> anyhow::Result<()> {
     let subcommand_name = match subcommand {
@@ -1483,7 +1525,12 @@ fn reject_remote_mode_for_app_server_subcommand(
             "app-server generate-internal-json-schema"
         }
     };
-    reject_remote_mode_for_subcommand(remote, remote_auth_token_env, subcommand_name)
+    reject_remote_mode_for_subcommand(
+        remote,
+        remote_auth_token_env,
+        exit_after_turn,
+        subcommand_name,
+    )
 }
 
 fn read_remote_auth_token_from_env_var_with<F>(
@@ -1510,6 +1557,7 @@ async fn run_interactive_tui(
     mut interactive: TuiCli,
     remote: Option<String>,
     remote_auth_token_env: Option<String>,
+    exit_after_turn: bool,
     arg0_paths: Arg0DispatchPaths,
 ) -> std::io::Result<AppExitInfo> {
     if let Some(prompt) = interactive.prompt.take() {
@@ -1545,6 +1593,16 @@ async fn run_interactive_tui(
             "`--remote-auth-token-env` requires `--remote`.",
         ));
     }
+    if exit_after_turn && normalized_remote.is_none() {
+        return Ok(AppExitInfo::fatal(
+            "`--exit-after-turn` requires `--remote`.",
+        ));
+    }
+    if exit_after_turn && interactive.prompt.is_none() {
+        return Ok(AppExitInfo::fatal(
+            "`--exit-after-turn` requires an initial prompt.",
+        ));
+    }
     let remote_auth_token = remote_auth_token_env
         .as_deref()
         .map(read_remote_auth_token_from_env_var)
@@ -1556,6 +1614,7 @@ async fn run_interactive_tui(
         codex_config::LoaderOverrides::default(),
         normalized_remote,
         remote_auth_token,
+        exit_after_turn,
     )
     .await
 }
@@ -2177,6 +2236,20 @@ mod tests {
     }
 
     #[test]
+    fn exit_after_turn_flag_parses_for_interactive_root() {
+        let cli = MultitoolCli::try_parse_from([
+            "codex",
+            "--remote",
+            "ws://127.0.0.1:4500",
+            "--exit-after-turn",
+            "hello",
+        ])
+        .expect("parse");
+        assert!(cli.remote.exit_after_turn);
+        assert_eq!(cli.interactive.prompt.as_deref(), Some("hello"));
+    }
+
+    #[test]
     fn remote_auth_token_env_flag_parses_for_interactive_root() {
         let cli = MultitoolCli::try_parse_from([
             "codex",
@@ -2210,9 +2283,23 @@ mod tests {
         let err = reject_remote_mode_for_subcommand(
             Some("127.0.0.1:4500"),
             /*remote_auth_token_env*/ None,
+            /*exit_after_turn*/ false,
             "exec",
         )
         .expect_err("non-interactive subcommands should reject --remote");
+        assert!(
+            err.to_string()
+                .contains("only supported for interactive TUI commands")
+        );
+    }
+
+    #[test]
+    fn reject_exit_after_turn_for_non_interactive_subcommands() {
+        let err = reject_remote_mode_for_subcommand(
+            /*remote*/ None, /*remote_auth_token_env*/ None,
+            /*exit_after_turn*/ true, "exec",
+        )
+        .expect_err("non-interactive subcommands should reject --exit-after-turn");
         assert!(
             err.to_string()
                 .contains("only supported for interactive TUI commands")
@@ -2224,6 +2311,7 @@ mod tests {
         let err = reject_remote_mode_for_subcommand(
             /*remote*/ None,
             Some("CODEX_REMOTE_AUTH_TOKEN"),
+            /*exit_after_turn*/ false,
             "exec",
         )
         .expect_err("non-interactive subcommands should reject --remote-auth-token-env");
@@ -2242,6 +2330,7 @@ mod tests {
         let err = reject_remote_mode_for_app_server_subcommand(
             /*remote*/ None,
             Some("CODEX_REMOTE_AUTH_TOKEN"),
+            /*exit_after_turn*/ false,
             Some(&subcommand),
         )
         .expect_err("non-interactive app-server subcommands should reject --remote-auth-token-env");
@@ -2371,6 +2460,7 @@ mod tests {
         let err = reject_remote_mode_for_app_server_subcommand(
             /*remote*/ None,
             Some("CODEX_REMOTE_AUTH_TOKEN"),
+            /*exit_after_turn*/ false,
             Some(&subcommand),
         )
         .expect_err("app-server proxy should reject --remote-auth-token-env");

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -407,6 +407,7 @@ fn auto_review_mode() -> AutoReviewMode {
 /// Smooth-mode streaming drains one line per tick, so this interval controls
 /// perceived typing speed for non-backlogged output.
 const COMMIT_ANIMATION_TICK: Duration = tui::TARGET_FRAME_INTERVAL;
+const EXIT_AFTER_TURN_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[cfg(test)]
 fn try_enqueue_commit_tick(tx: &AppEventSender, pending: &AtomicBool) -> bool {
@@ -722,6 +723,10 @@ pub(crate) struct App {
     environment_manager: Arc<EnvironmentManager>,
     remote_app_server_url: Option<String>,
     remote_app_server_auth_token: Option<String>,
+    exit_after_turn: bool,
+    exit_after_turn_observed_assistant_output: bool,
+    exit_after_turn_thread_id: Option<String>,
+    exit_after_turn_turn_id: Option<String>,
     /// Set when the user confirms an update; propagated on exit.
     pub(crate) pending_update_action: Option<UpdateAction>,
 
@@ -860,6 +865,7 @@ impl App {
         should_prompt_windows_sandbox_nux_at_startup: bool,
         remote_app_server_url: Option<String>,
         remote_app_server_auth_token: Option<String>,
+        exit_after_turn: bool,
         environment_manager: Arc<EnvironmentManager>,
     ) -> Result<AppExitInfo> {
         use tokio_stream::StreamExt;
@@ -1116,6 +1122,10 @@ impl App {
             environment_manager,
             remote_app_server_url,
             remote_app_server_auth_token,
+            exit_after_turn,
+            exit_after_turn_observed_assistant_output: false,
+            exit_after_turn_thread_id: None,
+            exit_after_turn_turn_id: None,
             pending_update_action: None,
             pending_shutdown_exit_thread_id: None,
             windows_sandbox: WindowsSandboxState::default(),
@@ -1236,13 +1246,22 @@ impl App {
                         app.active_thread_rx.is_some()
                     ) => {
                         if let Some(event) = active {
+                            let exit_after_turn_event = event.clone();
                             if let Err(err) = app.handle_active_thread_event(tui, &mut app_server, event).await {
                                 break Err(err);
+                            }
+                            if let Some(exit_reason) = app.exit_after_turn_control_for_event(&exit_after_turn_event) {
+                                break Ok(exit_reason);
                             }
                         } else {
                             app.clear_active_thread().await;
                         }
                         AppRunControl::Continue
+                    }
+                    _ = tokio::time::sleep(EXIT_AFTER_TURN_TIMEOUT), if app.exit_after_turn => {
+                        AppRunControl::Exit(ExitReason::Fatal(
+                            "Remote turn did not complete before --exit-after-turn timeout.".to_string(),
+                        ))
                     }
                     event = tui_events.next() => {
                         if let Some(event) = event {
@@ -19989,6 +20008,10 @@ guardian_approval = true
             oracle_picker_remote_list_notice: None,
             oracle_broker: None,
             oracle_test_broker_hooks: Arc::new(StdMutex::new(OracleTestBrokerHooks::default())),
+            exit_after_turn: false,
+            exit_after_turn_observed_assistant_output: false,
+            exit_after_turn_thread_id: None,
+            exit_after_turn_turn_id: None,
             pending_plugin_enabled_writes: HashMap::new(),
         }
     }
@@ -20059,6 +20082,10 @@ guardian_approval = true
                 oracle_picker_remote_list_notice: None,
                 oracle_broker: None,
                 oracle_test_broker_hooks: Arc::new(StdMutex::new(OracleTestBrokerHooks::default())),
+                exit_after_turn: false,
+                exit_after_turn_observed_assistant_output: false,
+                exit_after_turn_thread_id: None,
+                exit_after_turn_turn_id: None,
                 pending_plugin_enabled_writes: HashMap::new(),
             },
             rx,

--- a/codex-rs/tui/src/app/app_server_adapter.rs
+++ b/codex-rs/tui/src/app/app_server_adapter.rs
@@ -152,11 +152,26 @@ impl App {
         }
     }
 
+    fn note_exit_after_turn_server_notification(&mut self, notification: &ServerNotification) {
+        if let Some(exit_reason) = self.exit_after_turn_control_for_notification(notification) {
+            match exit_reason {
+                crate::ExitReason::UserRequested => {
+                    self.app_event_tx
+                        .send(AppEvent::Exit(crate::app_event::ExitMode::Immediate));
+                }
+                crate::ExitReason::Fatal(message) => {
+                    self.app_event_tx.send(AppEvent::FatalExitRequest(message));
+                }
+            }
+        }
+    }
+
     async fn handle_server_notification_event(
         &mut self,
         app_server_client: &AppServerSession,
         notification: ServerNotification,
     ) {
+        self.note_exit_after_turn_server_notification(&notification);
         match &notification {
             ServerNotification::ServerRequestResolved(notification) => {
                 if let Some(request) = self
@@ -1088,6 +1103,7 @@ mod tests {
     use codex_app_server_protocol::Turn;
     use codex_app_server_protocol::TurnCompletedNotification;
     use codex_app_server_protocol::TurnError;
+    #[cfg(test)]
     use codex_app_server_protocol::TurnStatus;
     use codex_app_server_protocol::WarningNotification;
     use codex_protocol::ThreadId;

--- a/codex-rs/tui/src/app/test_support.rs
+++ b/codex-rs/tui/src/app/test_support.rs
@@ -68,6 +68,10 @@ pub(super) async fn make_test_app() -> App {
         oracle_picker_remote_list_notice: None,
         oracle_broker: None,
         oracle_test_broker_hooks: Arc::new(StdMutex::new(OracleTestBrokerHooks::default())),
+        exit_after_turn: false,
+        exit_after_turn_observed_assistant_output: false,
+        exit_after_turn_thread_id: None,
+        exit_after_turn_turn_id: None,
         pending_plugin_enabled_writes: HashMap::new(),
     }
 }

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -32,6 +32,7 @@ use codex_app_server_protocol::CommandExecutionRequestApprovalParams;
 use codex_app_server_protocol::ConfigWarningNotification;
 use codex_app_server_protocol::FileChangeRequestApprovalParams;
 use codex_app_server_protocol::FileUpdateChange;
+use codex_app_server_protocol::ItemCompletedNotification;
 use codex_app_server_protocol::ItemStartedNotification;
 use codex_app_server_protocol::JSONRPCErrorError;
 use codex_app_server_protocol::McpServerStartupState;
@@ -69,6 +70,7 @@ use codex_protocol::config_types::ModeKind;
 use codex_protocol::config_types::Settings;
 use codex_protocol::models::AdditionalPermissionProfile as CoreAdditionalPermissionProfile;
 use codex_protocol::models::FileSystemPermissions;
+use codex_protocol::models::MessagePhase;
 use codex_protocol::models::NetworkPermissions;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
@@ -3754,6 +3756,10 @@ async fn make_test_app() -> App {
         environment_manager: Arc::new(EnvironmentManager::default_for_tests()),
         remote_app_server_url: None,
         remote_app_server_auth_token: None,
+        exit_after_turn: false,
+        exit_after_turn_observed_assistant_output: false,
+        exit_after_turn_thread_id: None,
+        exit_after_turn_turn_id: None,
         pending_update_action: None,
         pending_shutdown_exit_thread_id: None,
         windows_sandbox: WindowsSandboxState::default(),
@@ -3849,6 +3855,10 @@ async fn make_test_app_with_channels() -> (
             oracle_picker_remote_list_notice: None,
             oracle_broker: None,
             oracle_test_broker_hooks: Arc::new(StdMutex::new(OracleTestBrokerHooks::default())),
+            exit_after_turn: false,
+            exit_after_turn_observed_assistant_output: false,
+            exit_after_turn_thread_id: None,
+            exit_after_turn_turn_id: None,
             pending_plugin_enabled_writes: HashMap::new(),
         },
         rx,
@@ -5164,4 +5174,245 @@ async fn session_summary_uses_id_even_when_thread_has_name() {
         summary.resume_command,
         Some("codex resume 123e4567-e89b-12d3-a456-426614174000".to_string())
     );
+}
+
+#[tokio::test]
+async fn exit_after_turn_waits_for_completed_remote_turn_with_output() -> Result<()> {
+    let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+    app.exit_after_turn = true;
+    let thread_id = ThreadId::new().to_string();
+    let turn_id = "turn-exit-after-output".to_string();
+
+    assert!(
+        app.exit_after_turn_control_for_event(&ThreadBufferedEvent::Notification(
+            ServerNotification::TurnStarted(TurnStartedNotification {
+                thread_id: thread_id.clone(),
+                turn: Turn {
+                    id: turn_id.clone(),
+                    items: Vec::new(),
+                    status: TurnStatus::InProgress,
+                    error: None,
+                    started_at: None,
+                    completed_at: None,
+                    duration_ms: None,
+                },
+            }),
+        ))
+        .is_none()
+    );
+
+    app.exit_after_turn_control_for_event(&ThreadBufferedEvent::Notification(
+        ServerNotification::ItemCompleted(ItemCompletedNotification {
+            thread_id: thread_id.clone(),
+            turn_id: turn_id.clone(),
+            item: ThreadItem::AgentMessage {
+                id: "item-agent".to_string(),
+                text: "OK".to_string(),
+                phase: Some(MessagePhase::FinalAnswer),
+                memory_citation: None,
+            },
+        }),
+    ));
+
+    let event = ThreadBufferedEvent::Notification(ServerNotification::TurnCompleted(
+        TurnCompletedNotification {
+            thread_id,
+            turn: Turn {
+                id: turn_id,
+                items: Vec::new(),
+                status: TurnStatus::Completed,
+                error: None,
+                started_at: None,
+                completed_at: None,
+                duration_ms: Some(1),
+            },
+        },
+    ));
+
+    assert!(matches!(
+        app.exit_after_turn_control_for_event(&event),
+        Some(ExitReason::UserRequested)
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn exit_after_turn_fails_completed_remote_turn_without_output() -> Result<()> {
+    let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+    app.exit_after_turn = true;
+    let event = ThreadBufferedEvent::Notification(ServerNotification::TurnCompleted(
+        TurnCompletedNotification {
+            thread_id: ThreadId::new().to_string(),
+            turn: Turn {
+                id: "turn-no-output".to_string(),
+                items: Vec::new(),
+                status: TurnStatus::Completed,
+                error: None,
+                started_at: None,
+                completed_at: None,
+                duration_ms: Some(1),
+            },
+        },
+    ));
+
+    assert!(matches!(
+        app.exit_after_turn_control_for_event(&event),
+        Some(ExitReason::Fatal(message)) if message.contains("without assistant output")
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn exit_after_turn_allows_agent_message_completion_plus_idle_fallback() -> Result<()> {
+    let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+    app.exit_after_turn = true;
+    let thread_id = ThreadId::new().to_string();
+    let turn_id = "turn-idle-fallback".to_string();
+
+    assert!(
+        app.exit_after_turn_control_for_event(&ThreadBufferedEvent::Notification(
+            ServerNotification::TurnStarted(TurnStartedNotification {
+                thread_id: thread_id.clone(),
+                turn: Turn {
+                    id: turn_id.clone(),
+                    items: Vec::new(),
+                    status: TurnStatus::InProgress,
+                    error: None,
+                    started_at: None,
+                    completed_at: None,
+                    duration_ms: None,
+                },
+            }),
+        ))
+        .is_none()
+    );
+
+    app.exit_after_turn_control_for_event(&ThreadBufferedEvent::Notification(
+        ServerNotification::ItemCompleted(ItemCompletedNotification {
+            thread_id: thread_id.clone(),
+            turn_id,
+            item: ThreadItem::AgentMessage {
+                id: "item-agent-idle".to_string(),
+                text: "OK idle fallback".to_string(),
+                phase: Some(MessagePhase::FinalAnswer),
+                memory_citation: None,
+            },
+        }),
+    ));
+
+    let event = ThreadBufferedEvent::Notification(ServerNotification::ThreadStatusChanged(
+        codex_app_server_protocol::ThreadStatusChangedNotification {
+            thread_id,
+            status: codex_app_server_protocol::ThreadStatus::Idle,
+        },
+    ));
+
+    assert!(matches!(
+        app.exit_after_turn_control_for_event(&event),
+        Some(ExitReason::UserRequested)
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn exit_after_turn_ignores_non_target_thread_completion() -> Result<()> {
+    let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+    app.exit_after_turn = true;
+    let target_thread_id = ThreadId::new().to_string();
+    let other_thread_id = ThreadId::new().to_string();
+
+    assert!(
+        app.exit_after_turn_control_for_event(&ThreadBufferedEvent::Notification(
+            ServerNotification::TurnStarted(TurnStartedNotification {
+                thread_id: target_thread_id.clone(),
+                turn: Turn {
+                    id: "target-turn".to_string(),
+                    items: Vec::new(),
+                    status: TurnStatus::InProgress,
+                    error: None,
+                    started_at: None,
+                    completed_at: None,
+                    duration_ms: None,
+                },
+            }),
+        ))
+        .is_none()
+    );
+
+    assert!(
+        app.exit_after_turn_control_for_event(&ThreadBufferedEvent::Notification(
+            ServerNotification::ItemCompleted(ItemCompletedNotification {
+                thread_id: other_thread_id.clone(),
+                turn_id: "other-turn".to_string(),
+                item: ThreadItem::AgentMessage {
+                    id: "other-item".to_string(),
+                    text: "side output".to_string(),
+                    phase: Some(MessagePhase::FinalAnswer),
+                    memory_citation: None,
+                },
+            }),
+        ))
+        .is_none()
+    );
+
+    assert!(
+        app.exit_after_turn_control_for_event(&ThreadBufferedEvent::Notification(
+            ServerNotification::TurnCompleted(TurnCompletedNotification {
+                thread_id: other_thread_id,
+                turn: Turn {
+                    id: "other-turn".to_string(),
+                    items: Vec::new(),
+                    status: TurnStatus::Completed,
+                    error: None,
+                    started_at: None,
+                    completed_at: None,
+                    duration_ms: Some(1),
+                },
+            }),
+        ))
+        .is_none()
+    );
+
+    let target_completed = ThreadBufferedEvent::Notification(ServerNotification::TurnCompleted(
+        TurnCompletedNotification {
+            thread_id: target_thread_id,
+            turn: Turn {
+                id: "target-turn".to_string(),
+                items: Vec::new(),
+                status: TurnStatus::Completed,
+                error: None,
+                started_at: None,
+                completed_at: None,
+                duration_ms: Some(1),
+            },
+        },
+    ));
+
+    assert!(matches!(
+        app.exit_after_turn_control_for_event(&target_completed),
+        Some(ExitReason::Fatal(message)) if message.contains("without assistant output")
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn normal_remote_mode_ignores_turn_completion_for_process_exit() -> Result<()> {
+    let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+    let event = ThreadBufferedEvent::Notification(ServerNotification::TurnCompleted(
+        TurnCompletedNotification {
+            thread_id: ThreadId::new().to_string(),
+            turn: Turn {
+                id: "turn-normal-mode".to_string(),
+                items: Vec::new(),
+                status: TurnStatus::Completed,
+                error: None,
+                started_at: None,
+                completed_at: None,
+                duration_ms: Some(1),
+            },
+        },
+    ));
+
+    assert!(app.exit_after_turn_control_for_event(&event).is_none());
+    Ok(())
 }

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -549,7 +549,7 @@ impl App {
                 }
                 if self
                     .maybe_route_natural_language_oracle_invocation(
-                        None, app_server, thread_id, items,
+                        /*tui*/ None, app_server, thread_id, items,
                     )
                     .await?
                 {
@@ -1480,6 +1480,139 @@ impl App {
                 self.handle_oracle_workflow_thread_event(event);
             }
         }
+    }
+
+    fn ensure_exit_after_turn_target(&mut self, thread_id: &str, turn_id: Option<&str>) -> bool {
+        if let Some(target_thread_id) = &self.exit_after_turn_thread_id
+            && target_thread_id != thread_id
+        {
+            return false;
+        }
+
+        if self.exit_after_turn_thread_id.is_none() {
+            self.exit_after_turn_thread_id = Some(thread_id.to_string());
+        }
+
+        if let Some(turn_id) = turn_id {
+            if let Some(target_turn_id) = &self.exit_after_turn_turn_id
+                && target_turn_id != turn_id
+            {
+                return false;
+            }
+            if self.exit_after_turn_turn_id.is_none() {
+                self.exit_after_turn_turn_id = Some(turn_id.to_string());
+            }
+        }
+
+        true
+    }
+
+    fn exit_after_turn_matches_target(&self, thread_id: &str, turn_id: Option<&str>) -> bool {
+        if self
+            .exit_after_turn_thread_id
+            .as_deref()
+            .is_some_and(|target_thread_id| target_thread_id != thread_id)
+        {
+            return false;
+        }
+        if let Some(turn_id) = turn_id
+            && self
+                .exit_after_turn_turn_id
+                .as_deref()
+                .is_some_and(|target_turn_id| target_turn_id != turn_id)
+        {
+            return false;
+        }
+        true
+    }
+
+    pub(super) fn exit_after_turn_control_for_notification(
+        &mut self,
+        notification: &ServerNotification,
+    ) -> Option<ExitReason> {
+        if !self.exit_after_turn {
+            return None;
+        }
+
+        match notification {
+            ServerNotification::TurnStarted(notification) => {
+                self.ensure_exit_after_turn_target(
+                    &notification.thread_id,
+                    Some(notification.turn.id.as_str()),
+                );
+                None
+            }
+            ServerNotification::ItemCompleted(notification) => {
+                if !self.exit_after_turn_matches_target(
+                    &notification.thread_id,
+                    Some(notification.turn_id.as_str()),
+                ) {
+                    return None;
+                }
+                if let codex_app_server_protocol::ThreadItem::AgentMessage { text, .. } =
+                    &notification.item
+                    && !text.trim().is_empty()
+                    && self.exit_after_turn_thread_id.is_some()
+                {
+                    self.exit_after_turn_observed_assistant_output = true;
+                }
+                None
+            }
+            ServerNotification::TurnCompleted(notification) => {
+                if !self.ensure_exit_after_turn_target(
+                    &notification.thread_id,
+                    Some(notification.turn.id.as_str()),
+                ) {
+                    return None;
+                }
+                match notification.turn.status {
+                    TurnStatus::Completed => {
+                        if self.exit_after_turn_observed_assistant_output {
+                            Some(ExitReason::UserRequested)
+                        } else {
+                            Some(ExitReason::Fatal(
+                                "Remote turn completed without assistant output.".to_string(),
+                            ))
+                        }
+                    }
+                    TurnStatus::Interrupted => Some(ExitReason::Fatal(
+                        "Remote turn was interrupted before completion.".to_string(),
+                    )),
+                    TurnStatus::Failed => Some(ExitReason::Fatal(
+                        notification
+                            .turn
+                            .error
+                            .as_ref()
+                            .map(|error| format!("Remote turn failed: {}", error.message))
+                            .unwrap_or_else(|| "Remote turn failed.".to_string()),
+                    )),
+                    TurnStatus::InProgress => None,
+                }
+            }
+            ServerNotification::ThreadStatusChanged(notification)
+                if matches!(
+                    notification.status,
+                    codex_app_server_protocol::ThreadStatus::Idle
+                ) && self.exit_after_turn_observed_assistant_output
+                    && self.exit_after_turn_matches_target(
+                        &notification.thread_id,
+                        /*turn_id*/ None,
+                    ) =>
+            {
+                Some(ExitReason::UserRequested)
+            }
+            _ => None,
+        }
+    }
+
+    pub(super) fn exit_after_turn_control_for_event(
+        &mut self,
+        event: &ThreadBufferedEvent,
+    ) -> Option<ExitReason> {
+        let ThreadBufferedEvent::Notification(notification) = event else {
+            return None;
+        };
+        self.exit_after_turn_control_for_notification(notification)
     }
 
     /// Handles an event emitted by the currently active thread.

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -680,6 +680,7 @@ pub async fn run_main(
     loader_overrides: LoaderOverrides,
     remote: Option<String>,
     remote_auth_token: Option<String>,
+    exit_after_turn: bool,
 ) -> std::io::Result<AppExitInfo> {
     let remote_url = remote;
     if let (Some(websocket_url), Some(_)) = (remote_url.as_deref(), remote_auth_token.as_ref()) {
@@ -1025,6 +1026,7 @@ pub async fn run_main(
         log_db,
         remote_url,
         remote_auth_token,
+        exit_after_turn,
         environment_manager,
     )
     .await
@@ -1046,6 +1048,7 @@ async fn run_ratatui_app(
     log_db: Option<log_db::LogDbLayer>,
     remote_url: Option<String>,
     remote_auth_token: Option<String>,
+    exit_after_turn: bool,
     environment_manager: Arc<EnvironmentManager>,
 ) -> color_eyre::Result<AppExitInfo> {
     let remote_mode = matches!(&app_server_target, AppServerTarget::Remote { .. });
@@ -1462,6 +1465,7 @@ async fn run_ratatui_app(
         should_prompt_windows_sandbox_nux_at_startup,
         remote_url,
         remote_auth_token,
+        exit_after_turn,
         environment_manager,
     )
     .await;

--- a/codex-rs/tui/src/main.rs
+++ b/codex-rs/tui/src/main.rs
@@ -59,6 +59,7 @@ fn main() -> anyhow::Result<()> {
             LoaderOverrides::default(),
             /*remote*/ None,
             /*remote_auth_token*/ None,
+            /*exit_after_turn*/ false,
         )
         .await?;
         match exit_info.exit_reason {


### PR DESCRIPTION
## Summary\n- add `--exit-after-turn` for remote interactive TUI sessions with an initial prompt\n- exit after app-server turn completion, or after agent-message completion plus thread idle when the app-server does not emit `turn/completed`\n- keep normal interactive remote behavior unchanged unless the flag is present\n\n## Validation\n- `git diff --check`\n- `cargo fmt --all -- --check`\n- `cargo test -p codex-cli exit_after_turn -- --nocapture`\n- `cargo test -p codex-tui exit_after_turn -- --nocapture`\n- `cargo test -p codex-tui normal_remote_mode_ignores_turn_completion_for_process_exit -- --nocapture`\n- `cargo check -p codex-cli --tests`\n- `cargo build -p codex-cli`\n- live smoke through smarty-agents app-server proxy exited 0 without external timeout\n