### PR TITLE
Add Smarty setup slash command

### DIFF
--- a/codex-rs/tui/src/smarty_setup.rs
+++ b/codex-rs/tui/src/smarty_setup.rs
@@ -32,7 +32,10 @@ pub(crate) fn run(cwd: &Path) -> SmartySetupResult {
             Ok(output) if output.status.success() => {
                 return SmartySetupResult {
                     message: format_setup_output(true, &output.stdout, &output.stderr),
-                    hint: Some("Rerun `smarty-codex` to enter through Smarty Agents.".to_string()),
+                    hint: Some(
+                        "Restart `smarty-codex` from the new Smarty-enabled worktree to enter through Smarty Agents."
+                            .to_string(),
+                    ),
                 };
             }
             Ok(output) => failures.push(format_setup_output(false, &output.stdout, &output.stderr)),


### PR DESCRIPTION
Adds the /smarty TUI setup command on top of the accepted remote --exit-after-turn lifecycle seam, so prepared Smarty worktrees can be bootstrapped from Codex.\n\nValidation already run on the pushed branch:\n- cargo fmt --check\n- cargo test -p codex-tui smarty -- --nocapture\n- cargo build --release -p codex-cli\n\nPublication cleanup for the smarty-codex daily-driver path.